### PR TITLE
Minor fixes in plot modules

### DIFF
--- a/dynamicopy/cartoplot.py
+++ b/dynamicopy/cartoplot.py
@@ -4,7 +4,6 @@
 
 import numpy as np
 import matplotlib.pyplot as plt
-from matplotlib.colors import TwoSlopeNorm
 import cartopy.crs as ccrs
 from .plot import _var2d
 
@@ -16,7 +15,7 @@ GeoAxes._pcolormesh_patched = Axes.pcolormesh
 # Actuellement, pour utiliser des subplots, les créer avec plt.subplots(a, b, subplot_kw = {'projection':ccrs.Robinson()})
 
 
-def lon_lat_plot_map(lon, lat, var, lon_axis=-1, lat_axis=-2, fig_ax=None, title='', cmap="bwr", colorbar_label='', norm=TwoSlopeNorm(vcenter=0), smooth=False, projection=ccrs.Robinson(), set_global=False, coastlines=True, grid=False):
+def lon_lat_plot_map(lon, lat, var, lon_axis=-1, lat_axis=-2, fig_ax=None, title='', cmap="bwr", colorbar_label='', norm=None, smooth=False, projection=ccrs.Robinson(), set_global=False, coastlines=True, grid=False):
     """Plot a 2D map of the data with cartopy.
 
     Parameters
@@ -75,7 +74,7 @@ def lon_lat_plot_map(lon, lat, var, lon_axis=-1, lat_axis=-2, fig_ax=None, title
 
     if not smooth:
         C = ax.pcolormesh(lon, lat, var2D, cmap=cmap,
-                          norm=norm, transform=ccrs.PlateCarree())
+                          norm=norm, transform=ccrs.PlateCarree(), shading = "nearest")
     else:
         C = ax.contourf(lon, lat, var2D, cmap=cmap, norm=norm,
                         transform=ccrs.PlateCarree())

--- a/dynamicopy/plot.py
+++ b/dynamicopy/plot.py
@@ -35,7 +35,7 @@ def _var2d(var, lon_axis=-1, lat_axis=-2):
     return np.mean(var, axis=tuple(axes_avg))
 
 
-def lon_lat_plot(lon, lat, var, lon_axis=-1, lat_axis=-2, fig_ax=plt.subplots(), title='', cmap="bwr", colorbar_label='', norm=None, smooth=False):
+def lon_lat_plot(lon, lat, var, lon_axis=-1, lat_axis=-2, fig_ax=None, title='', cmap="bwr", colorbar_label='', norm=None, smooth=False):
     """Plot a 2D map of the data.
 
     Parameters
@@ -72,9 +72,13 @@ def lon_lat_plot(lon, lat, var, lon_axis=-1, lat_axis=-2, fig_ax=plt.subplots(),
     var2D = _var2d(var, lon_axis, lat_axis)
 
     # Plotting
-    fig, ax = fig_ax
+    if fig_ax == None :
+        fig, ax = plt.subplots()
+    else :
+        fig, ax = fig_ax
+
     if not smooth:
-        C = ax.pcolormesh(lon, lat, var2D, cmap=cmap, norm=norm)
+        C = ax.pcolormesh(lon, lat, var2D, cmap=cmap, norm=norm, shading = "nearest")
     else:
         C = ax.contourf(lon, lat, var2D, cmap=cmap, norm=norm)
     fig.colorbar(C, ax=ax, label=colorbar_label,)

--- a/dynamicopy/plot.py
+++ b/dynamicopy/plot.py
@@ -4,7 +4,6 @@
 
 import numpy as np
 import matplotlib.pyplot as plt
-from matplotlib.colors import TwoSlopeNorm
 
 
 def _var2d(var, lon_axis=-1, lat_axis=-2):
@@ -36,7 +35,7 @@ def _var2d(var, lon_axis=-1, lat_axis=-2):
     return np.mean(var, axis=tuple(axes_avg))
 
 
-def lon_lat_plot(lon, lat, var, lon_axis=-1, lat_axis=-2, fig_ax=plt.subplots(), title='', cmap="bwr", colorbar_label='', norm=TwoSlopeNorm(vcenter=0), smooth=False):
+def lon_lat_plot(lon, lat, var, lon_axis=-1, lat_axis=-2, fig_ax=plt.subplots(), title='', cmap="bwr", colorbar_label='', norm=None, smooth=False):
     """Plot a 2D map of the data.
 
     Parameters
@@ -60,7 +59,7 @@ def lon_lat_plot(lon, lat, var, lon_axis=-1, lat_axis=-2, fig_ax=plt.subplots(),
     colorbar_label : str, optional
         label of the colorbar, by default ''
     norm : matplotlib.colors.<any>Norm, optional
-        normalization for the colormap, by default TwoSlopeNorm(vcenter=0)
+        normalization for the colormap, by default None
     smooth : bool, optional
         if True, contourf is used instead of pcolormesh, by default False
 
@@ -86,8 +85,6 @@ def lon_lat_plot(lon, lat, var, lon_axis=-1, lat_axis=-2, fig_ax=plt.subplots(),
     # To-Do : Be able to set level when smoothed or even for pcolormesh (Check what I did for the matrix in my article)
     return None
 
-
-lonLatPlot = lon_lat_plot
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Changes the default normalization behavior (norm = None by default, so that matplotlib default behavior is used. One must set norm=TwoSlopeNorm(vcenter=0) for previous behavior).
- Fixes issue with blank windows opening
- Fixes warning message due to deprecated usage of shading in matplotlib.pyplot.pcolormesh